### PR TITLE
Adding a SECURITY.md to the default repository template

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 # Reporting security issues
-We treat disclosure with care and respect as per the [security disclosure policy on our website](https://octopus.com/security/disclosure).
+We treat disclosure with care and respect as per the [security disclosure policy on our website](https://g.octopushq.com/disclosure).
 
 ## What do we consider a 'security issue'?
 We consider security bugs to be those that impact the confidentiality, integrity or availability of our applications.
@@ -7,7 +7,7 @@ We consider security bugs to be those that impact the confidentiality, integrity
 We use various sources such as [CVSS metrics](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator) and the [Bugcrowd Vulnerability Rating Taxonomy](https://bugcrowd.com/vulnerability-rating-taxonomy) to qualify the severity of security issues. We will prioritize higher impact issues over lower impact issues.
 
 ## Reporting a Vulnerability
-If you have found a vulnerability, please do not file a public issue. Please follow the [security disclosure policy on our website](https://octopus.com/security/disclosure) and send us your report privately via email to [security@octopus.com](mailto:security@octopus.com) and we'll triage the issue from there. When it is safe to do so, we will create a public issue to notify other consumers of this repository.
+If you have found a vulnerability, please do not file a public issue. Please follow the [security disclosure policy on our website](https://g.octopushq.com/disclosure) and send us your report privately via email to [security@octopus.com](mailto:security@octopus.com) and we'll triage the issue from there. When it is safe to do so, we will create a public issue to notify other consumers of this repository.
 
 ## Is there a bounty if I find an issue?
 We don't currently offer bounty rewards for finding security issues in this repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Reporting security issues
+We treat disclosure with care and respect as per our [security disclosure policy on our website](https://octopus.com/security/disclosure).
+
+## What do we consider a 'security issue'?
+We use sources such as CVSS metrics and the Bugcrowd VRT to qualify the severity of security issues. We will prioritize higher impact issues over lower impact issues.
+
+## Reporting a Vulnerability
+If you have found a vulnerability, please do not file a public issue. Please follow the [security disclosure policy on our website](https://octopus.com/security/disclosure) and send us your report privately via email to [security@octopus.com](mailto:security@octopus.com) and we'll triage the issue from there. When it is safe to do so, we will create a public issue to notify other consumers of this repository.
+
+## Is there a bounty if I find an issue?
+We don't currently offer bounty rewards for finding security issues in this repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,10 @@
 # Reporting security issues
-We treat disclosure with care and respect as per our [security disclosure policy on our website](https://octopus.com/security/disclosure).
+We treat disclosure with care and respect as per the [security disclosure policy on our website](https://octopus.com/security/disclosure).
 
 ## What do we consider a 'security issue'?
-We use sources such as CVSS metrics and the Bugcrowd VRT to qualify the severity of security issues. We will prioritize higher impact issues over lower impact issues.
+We consider security bugs to be those that impact the confidentiality, integrity or availability of our applications.
+
+We use various sources such as [CVSS metrics](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator) and the [Bugcrowd Vulnerability Rating Taxonomy](https://bugcrowd.com/vulnerability-rating-taxonomy) to qualify the severity of security issues. We will prioritize higher impact issues over lower impact issues.
 
 ## Reporting a Vulnerability
 If you have found a vulnerability, please do not file a public issue. Please follow the [security disclosure policy on our website](https://octopus.com/security/disclosure) and send us your report privately via email to [security@octopus.com](mailto:security@octopus.com) and we'll triage the issue from there. When it is safe to do so, we will create a public issue to notify other consumers of this repository.


### PR DESCRIPTION
To make it easier for casual observers & researchers alike to report security vulnerabilities, I've added a security.md with our 'default' stance on various concerns.